### PR TITLE
adding 12S db tutorial

### DIFF
--- a/notebooks/Make-12S-rRNA-gene-db.ipynb
+++ b/notebooks/Make-12S-rRNA-gene-db.ipynb
@@ -1,0 +1,347 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "45a36908",
+   "metadata": {},
+   "source": [
+    "# Making a 12S rRNA marker gene reference database.\n",
+    "\n",
+    "The 12S rRNA marker gene is commonly used in encironmental DNA (eDNA) surveys in various ways, from studying the diets of feral swine ([Anderson *et al*. 2018](http://dx.doi.org/10.5070/V42811017)), through the study of fish ([Milan *et al*. 2020](https://doi.org/10.1038/s41598-020-74902-3)).\n",
+    "\n",
+    "Below is an example of how [RESCRIPt](https://github.com/bokulich-lab/RESCRIPt), can make the process of making a custimized reference database much less onerous.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89996cee",
+   "metadata": {},
+   "source": [
+    "## Fetch 12S rRNA gene data\n",
+    "\n",
+    "To keep the example short and sweet, we'll use RESCRIPt's `get-ncbi-data` to fetch only metazoan sequences. More information can be found [here](https://forum.qiime2.org/t/using-rescript-to-compile-sequence-databases-and-taxonomy-classifiers-from-ncbi-genbank/15947). \n",
+    "\n",
+    "We'll also be sure to exclude a variety of potentially unhelpful reference sequences. We'll do all of this by using the following entrez search term:\n",
+    "`txid33208[ORGN] AND (12S[Title] OR 12S ribosomal RNA[Title] OR 12S rRNA[Title]) AND (mitochondrion[Filter] OR plastid[Filter]) NOT environmental sample[Title] NOT environmental samples[Title] NOT environmental[Title] NOT uncultured[Title] NOT unclassified[Title] NOT unidentified[Title] NOT unverified[Title]`\n",
+    "\n",
+    "Finally, we'll specify a list of taxonomic ranks that we'd like to extract for each sequence we download from GenBank. To make sure that we have a value for each rank, we'll eneable `--p-rank-propagation`. See the note on rank propagation within the [RESCRIPt SILVA tutorial](https://forum.qiime2.org/t/processing-filtering-and-evaluating-the-silva-database-and-other-reference-sequence-data-with-rescript/15494)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "56ce92bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mSaved FeatureData[Sequence] to: metazoan-12S-ref-seqs.qza\u001b[0m\n",
+      "\u001b[32mSaved FeatureData[Taxonomy] to: metazoan-12S-ref-tax.qza\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "! qiime rescript get-ncbi-data \\\n",
+    "    --p-query \"txid33208[ORGN] AND (12S[Title] OR 12S ribosomal RNA[Title] OR 12S rRNA[Title]) AND (mitochondrion[Filter] OR plastid[Filter]) NOT environmental sample[Title] NOT environmental samples[Title] NOT environmental[Title] NOT uncultured[Title] NOT unclassified[Title] NOT unidentified[Title] NOT unverified[Title]\" \\\n",
+    "    --p-ranks  superkingdom kingdom subkingdom superphylum phylum subphylum superclass class subclass superorder order suborder superfamily family subfamily genus \\\n",
+    "    --p-rank-propagation \\\n",
+    "    --p-n-jobs 4 \\\n",
+    "    --o-sequences metazoan-12S-ref-seqs.qza \\\n",
+    "    --o-taxonomy metazoan-12S-ref-tax.qza \\\n",
+    "    --verbose "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c11e6e96",
+   "metadata": {},
+   "source": [
+    "## Dereplicate data\n",
+    "\n",
+    "Sequence repositories like GenBank, and others, often contain quite a bit of redundant data. For example, different research groups may generate sequence data for the same set of taxa with similar approaches (*i.e.* identical primers). We'll dereplicate the sequence data to reduce the size of our database, which will also reduce the time spent on all other downstream database curational steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d0621552",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mSaved FeatureData[Sequence] to: metazoan-12S-ref-seqs-derep.qza\u001b[0m\n",
+      "\u001b[32mSaved FeatureData[Taxonomy] to: metazoan-12S-ref-tax-derep.qza\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "! qiime rescript dereplicate \\\n",
+    "    --i-sequences metazoan-12S-ref-seqs.qza \\\n",
+    "    --i-taxa metazoan-12S-ref-tax.qza \\\n",
+    "    --p-mode 'uniq' \\\n",
+    "    --p-threads 4 \\\n",
+    "    --p-rank-handles 'disable' \\\n",
+    "    --o-dereplicated-sequences metazoan-12S-ref-seqs-derep.qza \\\n",
+    "    --o-dereplicated-taxa metazoan-12S-ref-tax-derep.qza"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69ff18a4",
+   "metadata": {},
+   "source": [
+    "## Filter low-quality sequences\n",
+    "\n",
+    "It's quite common for sequence repositories like GenBank to contain sequence data with ambiguous IUPAC nucleotides like `N`, `R`, `Y`, `M` ..., etc. We can remove such sequences with the `cull-seqs` action. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b83b731b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mSaved FeatureData[Sequence] to: metazoan-12S-ref-seqs-cull.qza\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "! qiime rescript cull-seqs \\\n",
+    "    --i-sequences metazoan-12S-ref-seqs-derep.qza \\\n",
+    "    --p-n-jobs 4 \\\n",
+    "    --p-num-degenerates 5 \\\n",
+    "    --p-homopolymer-length 8 \\\n",
+    "    --o-clean-sequences metazoan-12S-ref-seqs-cull.qza"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bd04d82",
+   "metadata": {},
+   "source": [
+    "## Filter by sequence length\n",
+    "\n",
+    "The sequences we find on GenBank may be too short (or too long) for our needs. We can remove such sequences, for our purposes here. We'll make use of RESCRIPt's `filter-seqs-length` action. *Note, if you are interested in length trimming based on taxonomy you can use `filter-seqs-length-by-taxon`.*\n",
+    "\n",
+    "Most metazoan 12S rRNA sequences range from 800-1000 bp [Yang *et al*. 2014](https://doi.org/10.1038/srep04089). However, many researchers appear to sequence ~ 200-400 bp of this gene. Thus, we'll exclude any sequences less than 200 bp. We'll also exclude spuriously long sequences (~1200 bp) too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "aa47fac0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mSaved FeatureData[Sequence] to: metazoan-12S-ref-seqs-keep.qza\u001b[0m\n",
+      "\u001b[32mSaved FeatureData[Sequence] to: metazoan-12S-ref-seqs-discard.qza\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "! qiime rescript filter-seqs-length \\\n",
+    "    --i-sequences metazoan-12S-ref-seqs-cull.qza \\\n",
+    "    --p-global-min 200 \\\n",
+    "    --p-global-max 1200 \\\n",
+    "    --o-filtered-seqs metazoan-12S-ref-seqs-keep.qza \\\n",
+    "    --o-discarded-seqs metazoan-12S-ref-seqs-discard.qza"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b71717a",
+   "metadata": {},
+   "source": [
+    "## Let's take a look at what we've got!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "efa1f903",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mSaved FeatureData[Taxonomy] to: metazoan-12S-ref-tax-keep.qza\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# filter taxonomy file to match that of the sequence file\n",
+    "! qiime rescript filter-taxa \\\n",
+    "    --i-taxonomy metazoan-12S-ref-tax.qza \\\n",
+    "    --m-ids-to-keep-file metazoan-12S-ref-seqs-keep.qza \\\n",
+    "    --o-filtered-taxonomy metazoan-12S-ref-tax-keep.qza"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "eaf00579",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mSaved Visualization to: metazoan-12S-ref-tax-keep-eval.qzv\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "! qiime rescript evaluate-taxonomy \\\n",
+    "    --i-taxonomies metazoan-12S-ref-tax-keep.qza \\\n",
+    "    --o-taxonomy-stats metazoan-12S-ref-tax-keep-eval.qzv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "f6a04923",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mSaved Visualization to: metazoan-12S-ref-tax-keep.qzv\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "! qiime metadata tabulate \\\n",
+    "    --m-input-file metazoan-12S-ref-tax-keep.qza \\\n",
+    "    --o-visualization metazoan-12S-ref-tax-keep.qzv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "9fa23d39",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mSaved Visualization to: metazoan-12S-ref-seqs-keep-eval.qzv\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "! qiime rescript evaluate-seqs \\\n",
+    "    --i-sequences metazoan-12S-ref-seqs-keep.qza \\\n",
+    "    --p-kmer-lengths 32 16 8 \\\n",
+    "    --o-visualization metazoan-12S-ref-seqs-keep-eval.qzv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1159592",
+   "metadata": {},
+   "source": [
+    "As you can see, after all of our processing we have over 70k 12S rRNA reference sequences. We've also generated a few basic descriptors of these references too. Let's take these and build a classifier, and evaluate it. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e6f63a4",
+   "metadata": {},
+   "source": [
+    "## Build and evaluate our classifier\n",
+    "\n",
+    "We are now ready to construct a classifier for our 12S rRNA reference sequences. We'll use the `evaluate-fit-classifier`, as this will not only make our classifier just like `qiime feature-classifier fit-classifier-naive-bayes`, but will also provide an evaluation of our \"best-case estimate\" of accuracy (*i.e.*, when all query sequences have one or more known matches within our reference database. See our other [tutorials](https://github.com/bokulich-lab/RESCRIPt#using-rescript) for more details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "873c3fe0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mSaved TaxonomicClassifier to: ncbi-12S-metazoan-refseqs-classifier.qza\u001b[0m\n",
+      "\u001b[32mSaved Visualization to: ncbi-12S-metazoan-refseqs-classifier-evaluation.qzv\u001b[0m\n",
+      "\u001b[32mSaved FeatureData[Taxonomy] to: ncbi-12S-metazoan-refseqs-predicted-taxonomy.qza\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "! qiime rescript evaluate-fit-classifier \\\n",
+    "    --i-sequences metazoan-12S-ref-seqs-keep.qza \\\n",
+    "    --i-taxonomy metazoan-12S-ref-tax-keep.qza \\\n",
+    "    --p-n-jobs 2 \\\n",
+    "    --o-classifier ncbi-12S-metazoan-refseqs-classifier.qza \\\n",
+    "    --o-evaluation ncbi-12S-metazoan-refseqs-classifier-evaluation.qzv \\\n",
+    "    --o-observed-taxonomy ncbi-12S-metazoan-refseqs-predicted-taxonomy.qza"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "57497073",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mSaved Visualization to: ref-taxonomy-evaluation.qzv\u001b[0m\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "! qiime rescript evaluate-taxonomy \\\n",
+    "  --i-taxonomies metazoan-12S-ref-tax-keep.qza ncbi-12S-metazoan-refseqs-predicted-taxonomy.qza\\\n",
+    "  --p-labels ref-taxonomy predicted-taxonomy \\\n",
+    "  --o-taxonomy-stats ref-taxonomy-evaluation.qzv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3135780",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a notebook that contains a simple example of how to download and construct a reference taxonomy sequence db of the 12S rRNA gene.